### PR TITLE
Add enable/disable logging

### DIFF
--- a/SimpleLogger/SimpleLogger.h
+++ b/SimpleLogger/SimpleLogger.h
@@ -14,6 +14,8 @@ typedef void(^SLAmazonTaskUploadCompletionHandler)(AWSTask * _Nonnull task);
 
 @interface SimpleLogger : NSObject
 
+/// Logging allowed to write to file
+@property (nonatomic, assign) BOOL loggingEnabled;
 /// Number of days worth of logs to keep
 @property (nonatomic, assign) NSInteger retentionDays;
 /// Log statement date formatter
@@ -45,6 +47,12 @@ typedef void(^SLAmazonTaskUploadCompletionHandler)(AWSTask * _Nonnull task);
 
 /// Shared instance of SimpleLogger
 + (instancetype _Nonnull)sharedLogger;
+
+/**
+Set if logger should allow logging of events
+@param enabled If logging should be allowed
+*/
++ (void)setLoggingEnabled:(BOOL)enabled;
 
 /**
 Initialize shared logger with Amazon region, bucket, and credentials

--- a/SimpleLogger/SimpleLogger.m
+++ b/SimpleLogger/SimpleLogger.m
@@ -26,6 +26,7 @@
 - (id)init {
 	self = [super init];
 	
+	self.loggingEnabled = YES;
 	self.retentionDays = kLoggerRetentionDaysDefault;
 	self.logFormatter = [[NSDateFormatter alloc] init];
 	self.logFormatter.dateFormat = @"yyyy-MM-dd HH:mm:ss";
@@ -35,6 +36,11 @@
 	self.folderLocation = kLoggerFilenameFolderLocation;
 	
 	return self;
+}
+
++ (void)setLoggingEnabled:(BOOL)enabled {
+	SimpleLogger *logger = [SimpleLogger sharedLogger];
+	logger.loggingEnabled = enabled;
 }
 
 + (void)initWithAWSRegion:(AWSRegionType)region bucket:(NSString *)bucket accessToken:(NSString *)accessToken secret:(NSString *)secret {
@@ -51,11 +57,14 @@
 + (void)logEvent:(NSString *)event {
 	SimpleLogger *logger = [SimpleLogger sharedLogger];
 	
-	NSDate *date = [NSDate date];
-	NSString *eventString = [logger eventString:event forDate:date];
-	[logger writeLogEntry:eventString toFilename:[logger filenameForDate:date]];
-	
-	[logger truncateFilesBeyondRetentionForDate:date];
+	if (logger.loggingEnabled) {
+		// only allow logging if enabled
+		NSDate *date = [NSDate date];
+		NSString *eventString = [logger eventString:event forDate:date];
+		[logger writeLogEntry:eventString toFilename:[logger filenameForDate:date]];
+		
+		[logger truncateFilesBeyondRetentionForDate:date];
+	}
 }
 
 + (void)uploadAllFilesWithCompletion:(SLUploadCompletionHandler)completionHandler {

--- a/SimpleLoggerExample/SimpleLoggerTests/SLTestCase.m
+++ b/SimpleLoggerExample/SimpleLoggerTests/SLTestCase.m
@@ -98,6 +98,7 @@
 - (void)resetLoggerUploadInfo {
 	SimpleLogger *logger = [SimpleLogger sharedLogger];
 	
+	logger.loggingEnabled = YES;
 	logger.filenameFormatter.dateFormat = kLoggerFilenameDateFormat;
 	logger.retentionDays = kLoggerRetentionDaysDefault;
 	logger.uploadInProgress = NO;

--- a/SimpleLoggerExample/SimpleLoggerTests/SimpleLoggerTests.m
+++ b/SimpleLoggerExample/SimpleLoggerTests/SimpleLoggerTests.m
@@ -55,6 +55,18 @@
 	XCTAssertEqualObjects(logger.filenameExtension, kLoggerFilenameExtension);
 }
 
+- (void)testSetLoggingEnabledWorksCorrectly {
+	[SimpleLogger setLoggingEnabled:NO];
+	
+	SimpleLogger *logger = [SimpleLogger sharedLogger];
+	
+	XCTAssertFalse(logger.loggingEnabled);
+	
+	[SimpleLogger setLoggingEnabled:YES];
+	
+	XCTAssertTrue(logger.loggingEnabled);
+}
+
 - (void)testAmazonInitStoresValuesCorrectly {
 	[SimpleLogger initWithAWSRegion:AWSRegionUSEast1 bucket:@"test_bucket" accessToken:@"test_token" secret:@"test_secret"];
 	
@@ -92,6 +104,22 @@
 	
 	NSString *log = [SimpleLogger logOutputForFileDate:date];
 	NSString *compare = [NSString stringWithFormat:@"[%@] my test string\n[%@] other test string", [logger.logFormatter stringFromDate:date], [logger.logFormatter stringFromDate:date]];
+	XCTAssertNotNil(log);
+	XCTAssertEqualObjects(log, compare);
+}
+
+- (void)testLogEventSkippedWhenDisabled {
+	SimpleLogger *logger = [SimpleLogger sharedLogger];
+	NSDate *date = [NSDate date];
+	
+	[SimpleLogger logEvent:@"my test string"];
+	
+	[SimpleLogger setLoggingEnabled:NO];
+	
+	[SimpleLogger logEvent:@"other test string"];
+	
+	NSString *log = [SimpleLogger logOutputForFileDate:date];
+	NSString *compare = [NSString stringWithFormat:@"[%@] my test string", [logger.logFormatter stringFromDate:date]];
 	XCTAssertNotNil(log);
 	XCTAssertEqualObjects(log, compare);
 }


### PR DESCRIPTION
Allows user to disable logging for simulator and test runs to avoid logs piling up unnecessarily.