### PR TITLE
Awss3 tranfer utility conversion

### DIFF
--- a/SimpleLogger.podspec
+++ b/SimpleLogger.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'SimpleLogger'
-  s.version      = '1.0.5'
+  s.version      = '1.1'
   s.summary      = 'SimpleLogger is an easy to use log file generator for iOS that uploads to Amazon S3.'
 
   s.homepage     = 'https://github.com/simplymadeapps/simple-logger'

--- a/SimpleLogger/SimpleLogger.m
+++ b/SimpleLogger/SimpleLogger.m
@@ -151,6 +151,7 @@
 
 #pragma mark - Instance Methods
 - (void)uploadFilePathToAmazon:(NSString *)filename withBlock:(SLAmazonTaskUploadCompletionHandler)block {
+	/*
 	AWSS3TransferManagerUploadRequest *uploadRequest = [AWSS3TransferManagerUploadRequest new];
 	uploadRequest.body = [NSURL fileURLWithPath:[self fullFilePathForFilename:filename]];
 	uploadRequest.contentType = @"text/plain";
@@ -159,6 +160,13 @@
 	
 	AWSS3TransferManager *transferManager = [AWSS3TransferManager defaultS3TransferManager];
 	[[transferManager upload:uploadRequest] continueWithExecutor:[AWSExecutor mainThreadExecutor] withBlock:^id _Nullable(AWSTask * _Nonnull task) {
+		block(task);
+		return nil;
+	}];
+	*/
+	
+	AWSS3TransferUtility *transferUtility = [AWSS3TransferUtility defaultS3TransferUtility];
+	[[transferUtility uploadFile:[NSURL fileURLWithPath:[self fullFilePathForFilename:filename]] bucket:self.awsBucket key:[self bucketFileLocationForFilename:filename] contentType:@"text/plain" expression:nil completionHandler:nil] continueWithExecutor:[AWSExecutor defaultExecutor] withBlock:^id _Nullable(AWSTask * _Nonnull task) {
 		block(task);
 		return nil;
 	}];

--- a/SimpleLogger/SimpleLogger.m
+++ b/SimpleLogger/SimpleLogger.m
@@ -151,20 +151,6 @@
 
 #pragma mark - Instance Methods
 - (void)uploadFilePathToAmazon:(NSString *)filename withBlock:(SLAmazonTaskUploadCompletionHandler)block {
-	/*
-	AWSS3TransferManagerUploadRequest *uploadRequest = [AWSS3TransferManagerUploadRequest new];
-	uploadRequest.body = [NSURL fileURLWithPath:[self fullFilePathForFilename:filename]];
-	uploadRequest.contentType = @"text/plain";
-	uploadRequest.key = [self bucketFileLocationForFilename:filename];
-	uploadRequest.bucket = self.awsBucket;
-	
-	AWSS3TransferManager *transferManager = [AWSS3TransferManager defaultS3TransferManager];
-	[[transferManager upload:uploadRequest] continueWithExecutor:[AWSExecutor mainThreadExecutor] withBlock:^id _Nullable(AWSTask * _Nonnull task) {
-		block(task);
-		return nil;
-	}];
-	*/
-	
 	AWSS3TransferUtility *transferUtility = [AWSS3TransferUtility defaultS3TransferUtility];
 	[[transferUtility uploadFile:[NSURL fileURLWithPath:[self fullFilePathForFilename:filename]] bucket:self.awsBucket key:[self bucketFileLocationForFilename:filename] contentType:@"text/plain" expression:nil completionHandler:nil] continueWithExecutor:[AWSExecutor defaultExecutor] withBlock:^id _Nullable(AWSTask * _Nonnull task) {
 		block(task);

--- a/SimpleLoggerExample/SimpleLoggerTests/SimpleLoggerTests.m
+++ b/SimpleLoggerExample/SimpleLoggerTests/SimpleLoggerTests.m
@@ -416,6 +416,27 @@
 	[self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
+- (void)testUploadFileToAmazonReturnsBlock {
+	SimpleLogger *logger = [SimpleLogger sharedLogger];
+		
+	AWSTask *task = [[AWSTask alloc] init];
+	id taskMock = OCMPartialMock(task);
+	[[[taskMock stub] andReturn:[NSError errorWithDomain:@"com.test.error" code:123 userInfo:nil]] error];
+	[[[taskMock stub] andReturn:taskMock] continueWithExecutor:[OCMArg any] withBlock:[OCMArg invokeBlockWithArgs:taskMock, nil]];
+	
+	XCTestExpectation *expect = [self expectationWithDescription:@"Upload All Files"];
+	
+	[logger uploadFilePathToAmazon:@"test.log" withBlock:^(AWSTask * _Nonnull task) {
+		[expect fulfill];
+	}];
+	
+	[taskMock verify];
+	[taskMock stopMocking];
+	taskMock = nil;
+	
+	[self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
 #pragma mark - Private Methods
 - (void)testLastRetentionDateReturnsCorrectly {
 	SimpleLogger *logger = [SimpleLogger sharedLogger];

--- a/SimpleLoggerExample/SimpleLoggerTests/SimpleLoggerTests.m
+++ b/SimpleLoggerExample/SimpleLoggerTests/SimpleLoggerTests.m
@@ -381,6 +381,18 @@
 }
 
 - (void)testUploadFilesWithCompletionError {
+	SimpleLogger *logger = [SimpleLogger sharedLogger];
+	
+	AWSTask *task = [[AWSTask alloc] init];
+	id taskMock = OCMPartialMock(task);
+	[[[taskMock stub] andReturn:[NSError errorWithDomain:@"com.test.error" code:123 userInfo:nil]] error];
+	
+	id mock = OCMPartialMock(logger);
+	[[mock stub] uploadFilePathToAmazon:[OCMArg any] withBlock:[OCMArg checkWithBlock:^BOOL(SLAmazonTaskUploadCompletionHandler handler) {
+		handler(taskMock);
+		return YES;
+	}]];
+	
 	[SimpleLogger initWithAWSRegion:AWSRegionUSEast1 bucket:@"test_bucket" accessToken:@"test_token" secret:@"test_secret"];
 	
 	[self saveDummyFiles:1];
@@ -393,6 +405,13 @@
 		
 		[expect fulfill];
 	}];
+	
+	[mock verify];
+	[mock stopMocking];
+	mock = nil;
+	
+	[taskMock stopMocking];
+	taskMock = nil;
 	
 	[self waitForExpectationsWithTimeout:5 handler:nil];
 }

--- a/SimpleLoggerExample/SimpleLoggerTests/ViewControllerTests.m
+++ b/SimpleLoggerExample/SimpleLoggerTests/ViewControllerTests.m
@@ -71,10 +71,11 @@
 - (void)testLogDetailViewUploadIsCalled {
 	[SimpleLogger initWithAWSRegion:AWSRegionUSEast1 bucket:@"test_bucket" accessToken:@"test_token" secret:@"test_secret"];
 	
-	AWSS3TransferManager *transferManager = [AWSS3TransferManager defaultS3TransferManager];
+	AWSS3TransferUtility *transferUtility = [AWSS3TransferUtility defaultS3TransferUtility];
 
-	id mock = OCMPartialMock(transferManager);
-	[[[mock expect] upload:[OCMArg any]] continueWithExecutor:[OCMArg any] withBlock:[OCMArg any]];
+	id mock = OCMPartialMock(transferUtility);
+	//[[[mock expect] upload:[OCMArg any]] continueWithExecutor:[OCMArg any] withBlock:[OCMArg any]];
+	[[[mock expect] uploadFile:[OCMArg any] bucket:[OCMArg any] key:[OCMArg any] contentType:[OCMArg any] expression:nil completionHandler:nil] continueWithExecutor:[OCMArg any] withBlock:[OCMArg any]];
 
 	[tester tapViewWithAccessibilityLabel:@"Add"];
 	


### PR DESCRIPTION
Use the AWS transfer utility rather than transfer manager to support uploads in the background.