### PR TITLE
Add exception for iOS 10 runtime tests

### DIFF
--- a/SimpleLoggerExample/SimpleLoggerTests/SimpleLoggerTests.m
+++ b/SimpleLoggerExample/SimpleLoggerTests/SimpleLoggerTests.m
@@ -110,27 +110,35 @@
 }
 
 - (void)testEventStringGetsFormattedCorrectly_DefaultLocale {
-    SimpleLogger *logger = [SimpleLogger sharedLogger];
-    
-    NSString *eventString = [logger eventString:@"test event" forDate:[self testDate]];
-    
-    XCTAssertNotNil(eventString);
-    XCTAssertEqualObjects(eventString, @"[2017-07-15 10:10:00 CDT] test event");
+    if (@available(iOS 11.0, *)) {
+        // runtimes older than iOS 11 use UTC timezones which makes this test fail
+        // https://forums.developer.apple.com/thread/80172
+        SimpleLogger *logger = [SimpleLogger sharedLogger];
+        
+        NSString *eventString = [logger eventString:@"test event" forDate:[self testDate]];
+        
+        XCTAssertNotNil(eventString);
+        XCTAssertEqualObjects(eventString, @"[2017-07-15 10:10:00 CDT] test event");
+    }
 }
 
 - (void)testEventStringGetsFormattedCorrectly_NonENLocale {
-    id localeMock = OCMClassMock([NSLocale class]);
-    NSLocale *locale = [NSLocale localeWithLocaleIdentifier:@"ar"];
-    [[[localeMock stub] andReturn:locale] currentLocale];
-    
-    SimpleLogger *logger = [SimpleLogger sharedLogger];
-    
-    NSString *eventString = [logger eventString:@"test event" forDate:[self testDate]];
-    
-    XCTAssertNotNil(eventString);
-    XCTAssertEqualObjects(eventString, @"[2017-07-15 10:10:00 CDT] test event");
-    
-    [self verifyAndStopMocking:localeMock];
+    if (@available(iOS 11.0, *)) {
+        // runtimes older than iOS 11 use UTC timezones which makes this test fail
+        // https://forums.developer.apple.com/thread/80172
+        id localeMock = OCMClassMock([NSLocale class]);
+        NSLocale *locale = [NSLocale localeWithLocaleIdentifier:@"ar"];
+        [[[localeMock stub] andReturn:locale] currentLocale];
+        
+        SimpleLogger *logger = [SimpleLogger sharedLogger];
+        
+        NSString *eventString = [logger eventString:@"test event" forDate:[self testDate]];
+        
+        XCTAssertNotNil(eventString);
+        XCTAssertEqualObjects(eventString, @"[2017-07-15 10:10:00 CDT] test event");
+        
+        [self verifyAndStopMocking:localeMock];
+    }
 }
 
 - (void)testRemoveAllFilesWorksCorrectly {	

--- a/SimpleLoggerExample/SimpleLoggerTests/SimpleLoggerTests.m
+++ b/SimpleLoggerExample/SimpleLoggerTests/SimpleLoggerTests.m
@@ -110,35 +110,31 @@
 }
 
 - (void)testEventStringGetsFormattedCorrectly_DefaultLocale {
-    if (@available(iOS 11.0, *)) {
-        // runtimes older than iOS 11 use UTC timezones which makes this test fail
-        // https://forums.developer.apple.com/thread/80172
-        SimpleLogger *logger = [SimpleLogger sharedLogger];
-        
-        NSString *eventString = [logger eventString:@"test event" forDate:[self testDate]];
-        
-        XCTAssertNotNil(eventString);
-        XCTAssertEqualObjects(eventString, @"[2017-07-15 10:10:00 CDT] test event");
-    }
+    SimpleLogger *logger = [SimpleLogger sharedLogger];
+    
+    NSString *dateString = [logger.logFormatter stringFromDate:[self testDate]];
+    NSString *eventString = [logger eventString:@"test event" forDate:[self testDate]];
+    NSString *testString = [NSString stringWithFormat:@"[%@] test event", dateString];
+    
+    XCTAssertNotNil(eventString);
+    XCTAssertEqualObjects(eventString, testString);
 }
 
 - (void)testEventStringGetsFormattedCorrectly_NonENLocale {
-    if (@available(iOS 11.0, *)) {
-        // runtimes older than iOS 11 use UTC timezones which makes this test fail
-        // https://forums.developer.apple.com/thread/80172
-        id localeMock = OCMClassMock([NSLocale class]);
-        NSLocale *locale = [NSLocale localeWithLocaleIdentifier:@"ar"];
-        [[[localeMock stub] andReturn:locale] currentLocale];
-        
-        SimpleLogger *logger = [SimpleLogger sharedLogger];
-        
-        NSString *eventString = [logger eventString:@"test event" forDate:[self testDate]];
-        
-        XCTAssertNotNil(eventString);
-        XCTAssertEqualObjects(eventString, @"[2017-07-15 10:10:00 CDT] test event");
-        
-        [self verifyAndStopMocking:localeMock];
-    }
+    id localeMock = OCMClassMock([NSLocale class]);
+    NSLocale *locale = [NSLocale localeWithLocaleIdentifier:@"ar"];
+    [[[localeMock stub] andReturn:locale] currentLocale];
+    
+    SimpleLogger *logger = [SimpleLogger sharedLogger];
+    
+    NSString *dateString = [logger.logFormatter stringFromDate:[self testDate]];
+    NSString *eventString = [logger eventString:@"test event" forDate:[self testDate]];
+    NSString *testString = [NSString stringWithFormat:@"[%@] test event", dateString];
+    
+    XCTAssertNotNil(eventString);
+    XCTAssertEqualObjects(eventString, testString);
+    
+    [self verifyAndStopMocking:localeMock];
 }
 
 - (void)testRemoveAllFilesWorksCorrectly {	


### PR DESCRIPTION
There is an issue with older runtimes not using the system timezone for the simulator and it causes 2 tests to fail. Added exceptions for these 2 when running on iOS 10.